### PR TITLE
fix: use specific solana version - `1.14.16`

### DIFF
--- a/programs/protocol_product/Cargo.toml
+++ b/programs/protocol_product/Cargo.toml
@@ -18,5 +18,5 @@ dev = []
 
 [dependencies]
 anchor-lang = "0.27.0"
-solana-program = "~1.14.16"
+solana-program = "1.14.16"
 rust_decimal = "1.29.0"


### PR DESCRIPTION
Use `solana-program = "1.14.16"`