### PR TITLE
fix: max title size is 32, but check title is not blank or empty

### DIFF
--- a/programs/protocol_product/src/error.rs
+++ b/programs/protocol_product/src/error.rs
@@ -4,8 +4,8 @@ use anchor_lang::prelude::*;
 pub enum ProductError {
     #[msg("Product: commission rate must be >= 0 and <= 100.")]
     InvalidCommissionRate,
-    #[msg("Product: title length must be between 1 and 50 characters.")]
-    ProductTitleLen,
+    #[msg("Product: product title must not be empty.")]
+    ProductTitleEmpty,
     #[msg("Product: Commission supports up to 3 decimal places.")]
     CommissionPrecisionTooLarge,
 }

--- a/programs/protocol_product/src/instructions/product.rs
+++ b/programs/protocol_product/src/instructions/product.rs
@@ -16,8 +16,8 @@ pub fn create_product(
     validate_commission_rate(commission_rate)?;
 
     require!(
-        (1..=50).contains(&product_title.len()),
-        ProductError::ProductTitleLen
+        !&product_title.trim().is_empty(),
+        ProductError::ProductTitleEmpty
     );
 
     product.authority = *authority;
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    fn test_title_length_validation() {
+    fn test_title_must_not_be_empty_validation() {
         let mut empty_product_account = Product {
             authority: Default::default(),
             payer: Default::default(),
@@ -150,11 +150,11 @@ mod tests {
             &mut empty_product_account,
             &Pubkey::new_unique(),
             &Pubkey::new_unique(),
-            "123456789012345678901234567890123456789012345678901".to_string(),
+            "    ".to_string(),
             99.99,
             &Pubkey::new_unique(),
         );
-        let expected_error = Err(error!(ProductError::ProductTitleLen));
+        let expected_error = Err(error!(ProductError::ProductTitleEmpty));
         assert_eq!(expected_error, result);
 
         let result = create_product(
@@ -165,7 +165,7 @@ mod tests {
             99.99,
             &Pubkey::new_unique(),
         );
-        let expected_error = Err(error!(ProductError::ProductTitleLen));
+        let expected_error = Err(error!(ProductError::ProductTitleEmpty));
         assert_eq!(expected_error, result);
     }
 

--- a/programs/protocol_product/src/state/product.rs
+++ b/programs/protocol_product/src/state/product.rs
@@ -11,7 +11,7 @@ pub struct Product {
 }
 
 impl Product {
-    pub const PRODUCT_TITLE_MAX_LENGTH: usize = 50;
+    pub const PRODUCT_TITLE_MAX_LENGTH: usize = 32;
     pub const SIZE: usize = DISCRIMINATOR_SIZE +
         (PUB_KEY_SIZE * 3) + // authority, payer and commission_escrow
         vec_size (CHAR_SIZE, Product::PRODUCT_TITLE_MAX_LENGTH) + // product_title

--- a/tests/product_create.ts
+++ b/tests/product_create.ts
@@ -49,4 +49,24 @@ describe("Product Creation", () => {
       assert.equal(e.error.errorCode.code, "CommissionPrecisionTooLarge");
     }
   });
+
+  it("Invalid title - title is empty or blank", async () => {
+    try {
+      await protocolProduct.createProduct("", 99);
+      assert.fail(
+        "Test passed, but should have errored with ProductTitleEmpty",
+      );
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "ProductTitleEmpty");
+    }
+
+    try {
+      await protocolProduct.createProduct("  ", 99);
+      assert.fail(
+        "Test passed, but should have errored with ProductTitleEmpty",
+      );
+    } catch (e) {
+      assert.equal(e.error.errorCode.code, "ProductTitleEmpty");
+    }
+  });
 });


### PR DESCRIPTION
Max seed size for generating PDAs is 32, so a title max length of 50 is not possible. Change this limit to 32, but make sure the title is not blank or empty.

![image](https://user-images.githubusercontent.com/26204464/227505364-91c52528-a644-4f5a-8c5c-bbdde865f814.png)
